### PR TITLE
use JSON library instead.

### DIFF
--- a/lib/rspec/api_helpers/example_methods.rb
+++ b/lib/rspec/api_helpers/example_methods.rb
@@ -5,7 +5,7 @@ module Rspec
     module ExampleMethods
       def objectize_resources(json, root:)
         array = []
-        array_hash = HashWithIndifferentAccess.new(MultiJson.load(json))
+        array_hash = HashWithIndifferentAccess.new(JSON.load(json))
 
         if root
           array_hash = array_hash[root]
@@ -19,7 +19,7 @@ module Rspec
       end
 
       def objectize_resource(json, root:)
-        hash = HashWithIndifferentAccess.new(MultiJson.load(json))
+        hash = HashWithIndifferentAccess.new(JSON.load(json))
         if root
           obj = object_hash(hash[root])
         else


### PR DESCRIPTION
now, we need to depend on "multi_json" gem in order to use this library (which isn't declared in the gemspec as dependency).

default `json` library is good enough and that's why i am replacing `multi_json` with it.
